### PR TITLE
Enhance update method to support context for translations

### DIFF
--- a/src/Contracts/OdooClientContract.php
+++ b/src/Contracts/OdooClientContract.php
@@ -19,7 +19,7 @@ interface OdooClientContract
 
     public function create(string $model, array $data): int|array;
 
-    public function update(string $model, int|array $ids, array $data): ?int;
+    public function update(string $model, int|array $ids, array $data, array $context = []): ?int;
 
     public function delete(string $model, int|array $ids): ?int;
 

--- a/src/OdooClient.php
+++ b/src/OdooClient.php
@@ -105,12 +105,13 @@ class OdooClient implements OdooClientContract
         return $this->call($params->toArray());
     }
 
-    public function update(string $model, int|array $ids, array $data): ?int
+    public function update(string $model, int|array $ids, array $data, array $context = []): ?int
     {
         $params = new CallParamsDTO(
             model: $model,
             method: OperationMethods::Write,
             args: [$ids, $data],
+            context: $context,
         );
 
         return $this->call($params->toArray());

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -161,7 +161,7 @@ class QueryBuilder
 
     public function update(array $data): ?int
     {
-        return $this->odooClient->update($this->model, $this->ids(), $data);
+        return $this->odooClient->update($this->model, $this->ids(), $data, $this->context);
     }
 
     public function ids(): ?array

--- a/src/Testing/OdooClientFake.php
+++ b/src/Testing/OdooClientFake.php
@@ -8,9 +8,9 @@ use AlazziAz\OdooXmlrpc\DTO\CallParamsDTO;
 use AlazziAz\OdooXmlrpc\Enums\EndPoints;
 use AlazziAz\OdooXmlrpc\Enums\OperationMethods;
 use AlazziAz\OdooXmlrpc\QueryBuilder;
+use Laminas\Http\Client as HttpClient;
 use Laminas\Http\Client\Adapter\AdapterInterface;
 use Laminas\Http\Client\Adapter\Test;
-use Laminas\Http\Client as HttpClient;
 use Laminas\XmlRpc\Client;
 use Laminas\XmlRpc\Response;
 
@@ -143,12 +143,13 @@ class OdooClientFake implements OdooClientContract
         return $this->call($params->toArray());
     }
 
-    public function update(string $model, int|array $ids, array $data): ?int
+    public function update(string $model, int|array $ids, array $data, array $context = []): ?int
     {
         $params = new CallParamsDTO(
             model: $model,
             method: OperationMethods::Write,
             args: [$ids, $data],
+            context: $context,
         );
 
         return $this->call($params->toArray());


### PR DESCRIPTION
Modified the existing `update` method to accept an optional `context` parameter. This allows language-specific updates for translatable fields in Odoo models (e.g., `product.public.category`).

By passing a context like `['lang' => 'de_DE']`, the method now correctly updates translations in the specified language.

This change is backward-compatible — existing usages of `update` without context remain unaffected.
