### PR TITLE
Add PHP 8.3 and Laravel 13 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ The **Odoo XML-RPC Client** is a PHP package that provides a simple and easy-to-
 
 ## Requirements
 
-- PHP 8.1 or later
-- The laminas/laminas-xmlrpc package
+- PHP 8.3 or later
+- The laminas/laminas-xmlrpc package (version 3.0 or higher)
 
 ## Installation
 You can install the package via composer:

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
         }
     ],
     "require": {
-        "php": "^8.1.0",
-        "laminas/laminas-xmlrpc": "^2.16"
+        "php": "^8.3.0",
+        "laminas/laminas-xmlrpc": "^3.0"
     },
     "require-dev": {
         "laravel/pint": "^1.6",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "require": {
         "php": "^8.3.0",
         "laminas/laminas-xmlrpc": "^3.0",
-        "guzzlehttp/guzzle": "^7.10"
+        "guzzlehttp/guzzle": "^7.10",
+        "guzzlehttp/psr7": "^2.10"
     },
     "require-dev": {
         "laravel/pint": "^1.6",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
     ],
     "require": {
         "php": "^8.3.0",
-        "laminas/laminas-xmlrpc": "^3.0"
+        "laminas/laminas-xmlrpc": "^3.0",
+        "guzzlehttp/guzzle": "^7.10"
     },
     "require-dev": {
         "laravel/pint": "^1.6",

--- a/src/Odoo.php
+++ b/src/Odoo.php
@@ -15,20 +15,20 @@ class Odoo
      */
     public static function client(string $url, string $suffix, string $db, string $username, string $password): OdooClientContract
     {
-        $psr17  = new GuzzlePsr7Factory();
         $httpClient   = new GuzzleClient();
+        $httpFactory  = new GuzzlePsr7Factory();
 
         $commonClient = new Client(
             EndPoints::Common->getFullUrl($url, $suffix),
             $httpClient,
-            $psr17,
-            $psr17
+            $httpFactory,
+            $httpFactory
         );
         $objectClient = new Client(
             EndPoints::Object->getFullUrl($url, $suffix),
             $httpClient,
-            $psr17,
-            $psr17
+            $httpFactory,
+            $httpFactory
         );
 
         return new OdooClient(

--- a/src/Odoo.php
+++ b/src/Odoo.php
@@ -4,6 +4,8 @@ namespace AlazziAz\OdooXmlrpc;
 
 use AlazziAz\OdooXmlrpc\Contracts\OdooClientContract;
 use AlazziAz\OdooXmlrpc\Enums\EndPoints;
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Psr7\HttpFactory as GuzzlePsr7Factory;
 use Laminas\XmlRpc\Client;
 
 class Odoo
@@ -13,9 +15,21 @@ class Odoo
      */
     public static function client(string $url, string $suffix, string $db, string $username, string $password): OdooClientContract
     {
+        $psr17  = new GuzzlePsr7Factory();
+        $httpClient   = new GuzzleClient();
 
-        $commonClient = new Client(EndPoints::Common->getFullUrl($url, $suffix));
-        $objectClient = new Client(EndPoints::Object->getFullUrl($url, $suffix));
+        $commonClient = new Client(
+            EndPoints::Common->getFullUrl($url, $suffix),
+            $httpClient,
+            $psr17,
+            $psr17
+        );
+        $objectClient = new Client(
+            EndPoints::Object->getFullUrl($url, $suffix),
+            $httpClient,
+            $psr17,
+            $psr17
+        );
 
         return new OdooClient(
             commonClient: $commonClient,

--- a/src/OdooClient.php
+++ b/src/OdooClient.php
@@ -6,6 +6,7 @@ use AlazziAz\OdooXmlrpc\Concern\Filterable;
 use AlazziAz\OdooXmlrpc\Contracts\OdooClientContract;
 use AlazziAz\OdooXmlrpc\DTO\CallParamsDTO;
 use AlazziAz\OdooXmlrpc\Enums\OperationMethods;
+use AlazziAz\OdooXmlrpc\Value\XmlRpcBoolean;
 use Laminas\XmlRpc\Client;
 
 class OdooClient implements OdooClientContract
@@ -48,7 +49,7 @@ class OdooClient implements OdooClientContract
             $this->password,
         ], $params);
 
-        return $this->objectClient->call('execute_kw', $params);
+        return $this->objectClient->call('execute_kw', $this->wrapBooleans($params));
     }
 
     public function getUid(): int
@@ -170,4 +171,17 @@ class OdooClient implements OdooClientContract
     {
         return $this->objectClient;
     }
+
+    private function wrapBooleans(mixed $value): mixed
+    {
+        if (is_bool($value)) {
+            return new XmlRpcBoolean($value);
+        }
+        if (is_array($value)) {
+            return array_map(fn ($v) => $this->wrapBooleans($v), $value);
+        }
+
+        return $value;
+    }
+
 }

--- a/src/Value/XmlRpcBoolean.php
+++ b/src/Value/XmlRpcBoolean.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AlazziAz\OdooXmlrpc\Value;
+
+use Laminas\XmlRpc\AbstractValue;
+use Laminas\XmlRpc\Value\AbstractScalar;
+use Override;
+
+final class XmlRpcBoolean extends AbstractScalar
+{
+    public function __construct(bool $value)
+    {
+        $this->type  = AbstractValue::XMLRPC_TYPE_BOOLEAN;
+        $this->value = $value ? 1 : 0;  // serialize as <boolean>0|1</boolean>
+    }
+
+    #[Override]
+    public function getValue(): bool
+    {
+        return (bool) $this->value;
+    }
+}
+


### PR DESCRIPTION
# Summary
  
 Upgrades the package to support PHP 8.3+ and laminas/laminas-xmlrpc v3, and fixes a boolean serialization regression introduced by the v3 upgrade.

## Changes

### Dependency upgrades (composer.json, README.md)

  - Bumps minimum PHP from ^8.1 to ^8.3.
  - Bumps `laminas/laminas-xmlrpc` from ^2.16 to ^3.0.
  - Adds `guzzlehttp/guzzle ^7.10` and `guzzlehttp/psr7 ^2.10` — laminas-xmlrpc v3 no longer ships an HTTP client and now requires a PSR-18 client plus PSR-17 factories to be injected explicitly.

### Odoo client instantiation (src/Odoo.php)

  - Constructs a GuzzleHttp\Client and a GuzzleHttp\Psr7\HttpFactory, and passes them into both Laminas\XmlRpc\Client instances (common + object endpoints) to satisfy v3's new constructor signature.

### Boolean serialization fix (src/OdooClient.php, src/Value/XmlRpcBoolean.php)

  - laminas-xmlrpc v3 serializes PHP true/false as `<boolean>true</boolean>` / `<boolean>false</boolean>`, but Odoo's XML-RPC server only accepts the canonical `<boolean>1</boolean>` /
  `<boolean>0</boolean>` form, causing calls with boolean arguments (e.g. active, domain operators) to fail.
  - Adds a small XmlRpcBoolean value class extending Laminas\XmlRpc\Value\AbstractScalar that forces the underlying value to 1/0 while keeping the boolean type tag.
  - OdooClient::call() now recursively wraps any bool in the params tree via wrapBooleans() before handing them to execute_kw.

### Compatibility note

  - Consumers must now be on PHP 8.3. This is a breaking change relative to the previous ^8.1 / laminas v2 baseline.

